### PR TITLE
fixed grammatical errors in arabic language

### DIFF
--- a/locales/ar/translation.json
+++ b/locales/ar/translation.json
@@ -13,8 +13,8 @@
     "notAcovidPass": "عذرًا، هذا لا يبدو أنه COVIDpass. يرجى الاتصال بـ [وزارة الصحة]({{link}})"
   },
   "thisLanguage": {
-    "callToAction": "استخدم vaxxed.as باللغة الإنجليزية",
-    "name": "الإنجليزية"
+    "callToAction": "باللغة العربية vaxxed.as استخدم",
+    "name": "عربي"
   },
   "verificationDialog": {
     "Attention needed": "يجب الانتباه",

--- a/src/data/languageOptions.json
+++ b/src/data/languageOptions.json
@@ -1,8 +1,8 @@
 [
   {
     "value": "ar",
-    "name": "الإنجليزية",
-    "callToAction": "استخدم vaxxed.as باللغة الإنجليزية",
+    "name": "عربي",
+    "callToAction": "باللغة العربية vaxxed.as استخدم",
     "isRTL": true,
     "changeLanguage": "غير اللغة"
   },


### PR DESCRIPTION
- Weird things happen when mixing RTL and LTR languages in the same sentence, so I changed the positioning of the words to make it more grammatically correct
- The title identified the language as "الإنجليزية" which translates to "English" but that is now changed to "عربي" which translates to "Arabic"